### PR TITLE
Update Vim link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Community members have created a bunch of editor plugins for Elm.
 - [IntelliJ](https://github.com/klazuka/intellij-elm) ✨
 - [Light Table](https://github.com/rundis/elm-light)
 - [Sublime Text](https://github.com/evancz/elm-syntax-highlighting/) ✨📊
-- [Vim](https://github.com/ElmCast/elm-vim)
+- [Vim](https://github.com/elm-tooling/elm-vim)
 - [VS Code](https://github.com/sbrink/vscode-elm)
 
 <br>


### PR DESCRIPTION
As discussed in #1, the currently linked project is no longer maintained.
The updated link is what is written in the description of #vim in the Elm Slack, and, being a newcomer to the Elm ecosystem, is what I was ultimately led to via asking how to set up Elm with Vim, in #beginners (after noticing the currently linked project was no longer maintained).